### PR TITLE
Fix for listListenerMatching in IE8 and potentially other browsers

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -488,7 +488,7 @@ function pathString(path) {
 function listListenerMatching (listeners, basePath) {
   var newListeners = [];
   for (var key in listeners) {
-    if (!listeners.hasOwnProperty(key)) return;
+    if (!listeners.hasOwnProperty(key)) continue;
     if (basePath.indexOf(key) !== 0) continue;
     newListeners.push(listeners[key]);
   }


### PR DESCRIPTION
Return causes `listListenerMatching` to return early with `undefined`. I believe the intention is to just ignore prototype properties.
